### PR TITLE
Fix warning about block declaration semantics

### DIFF
--- a/RFKeyboardToolbar/RFToolbarButton.h
+++ b/RFKeyboardToolbar/RFToolbarButton.h
@@ -10,7 +10,7 @@
 /**
  *  The block used for each button.
  */
-typedef void (^eventHandlerBlock)();
+typedef void (^eventHandlerBlock)(void);
 
 @interface RFToolbarButton : UIButton
 


### PR DESCRIPTION
Hi! I've been using your library for a couple of years - it's great! I noticed that since Xcode 9, this code causes a warning related to block declaration semantics: `This block declaration is not a prototype.` The fix [appears to be simple](https://stackoverflow.com/questions/44473146/this-function-declaration-is-not-a-prototype-warning-in-xcode-9). Hope you won't mind accepting this PR!